### PR TITLE
fix: replace pandas_ta with ft-pandas-ta

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ psycopg2-binary
 ipdb
 sklearn
 catboost
-pandas_ta
+ft-pandas-ta


### PR DESCRIPTION
[requirements.txt:6](https://github.com/p-zombie/freqtrade/blob/master/requirements.txt#L6) declares `pandas_ta` with no version constraint, and [user_data/strategies/NostalgiaForInfinityNextGen.py:26](https://github.com/p-zombie/freqtrade/blob/master/user_data/strategies/NostalgiaForInfinityNextGen.py#L26) uses `import pandas_ta as pta`.

Note that `pandas_ta` normalizes (PEP 503) to the PyPI package `pandas-ta`. Current state of that package on PyPI (checked 2026-08-30):

- older releases (e.g. 0.3.14b0) have been removed from PyPI (HTTP 404);
- only two releases remain — 0.4.67b0 (2025-09-03) and 0.4.71b (2025-09-14) — so an unconstrained `pandas_ta` install currently resolves to 0.4.71b;
- 0.4.71b declares `Requires-Python >=3.12` (install fails on Python<3.12 environments) and pins `numba==0.61.2` / `numpy>=2.2.6`; numba 0.61.2 (2025-04) ships no Python 3.14 wheels, so on the image's Python version pip would have to build numba from source;
- its metadata points to the original repository (twopirllc/pandas-ta), which now returns 404, so the provenance of this release cannot be verified on GitHub.

The Dockerfile is based on `freqtradeorg/freqtrade:stable` (built from `python:3.14.7-slim-trixie`, image updated 2026-08-31 for release 2026.8). That image already provides the `pandas_ta` module through the Freqtrade team's compatibility fork `ft-pandas-ta` (a dependency of the freqtrade bot itself); installing `pandas_ta` on top overwrites that module — both packages ship the same top-level `pandas_ta` module, and which one wins depends on install order.

The Freqtrade team maintains that compatibility fork at [freqtrade/pandas-ta](https://github.com/freqtrade/pandas-ta), published on PyPI as **`ft-pandas-ta`** (0.3.16, 2025-09-29). Unlike the removed original, it:

- keeps the top-level module **`pandas_ta`**, so `import pandas_ta as pta` keeps working **without any code change** (verified in the 0.3.16 wheel: module layout and the classic `bbands(close, length, std, ...)` signature / single-std column names are unchanged);
- has no `Requires-Python` gate and only requires `numpy<3.0.0, pandas`;
- is what the freqtrade project itself declares as its pandas-ta dependency.

This PR changes [requirements.txt:6](https://github.com/p-zombie/freqtrade/blob/master/requirements.txt#L6) from `pandas_ta` to `ft-pandas-ta` (unpinned, matching what the freqtrade project itself declares). `import pandas_ta as pta` keeps working without any code change.

Alternative: migrate to **pandas-ta-classic** (the actively maintained community fork, latest release 0.6.52) — this requires updating the imports in NostalgiaForInfinityNextGen.py / NostalgiaForInfinityX.py to `pandas_ta_classic`. Reference for that path: goldspanlabs/optopsy migrated to pandas-ta-classic ([PR #184](https://github.com/goldspanlabs/optopsy/pull/184), merged).

Fixes #13